### PR TITLE
Add 'options' arg to 'install', with 'extension' property

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,15 +3,17 @@ var React = require('react-tools');
 
 var installed = false;
 
-function install() {
+function install(options) {
   if (installed) {
     return;
   }
 
+  options = options || {};
+
   // Import everything in the transformer codepath before we add the import hook
   React.transform('');
 
-  require.extensions['.js'] = function(module, filename) {
+  require.extensions[options.extension || '.js'] = function(module, filename) {
     var src = fs.readFileSync(filename, {encoding: 'utf8'});
     src = React.transform(src);
     module._compile(src, filename);


### PR DESCRIPTION
Allow using like:

``` js
require('node-jsx').install({extension: '.jsx'})
```

It seems unnecessary to require the `/* @jsx React.DOM */` block if the file extension is `.jsx`.
