### PR TITLE
Add CoffeeScript support

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,14 +13,10 @@ function install(options) {
   // Import everything in the transformer codepath before we add the import hook
   React.transform('');
 
-  if (options.extension === '.coffee') {
-    var coffee = require('coffee-script');
-  }
-
   require.extensions[options.extension || '.js'] = function(module, filename) {
     var src = fs.readFileSync(filename, {encoding: 'utf8'});
-    if (options.extension === '.coffee') {
-      src = coffee.compile(src, {'bare': true});
+    if (typeof options.additionalTransform == 'function') {
+      src = options.additionalTransform(src);
     }
     src = React.transform(src);
     module._compile(src, filename);

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "transparently require() jsx from node",
   "main": "index.js",
   "dependencies": {
-    "react-tools": "~0.4.1",
-    "coffee-script": "~1.6.3"
+    "react-tools": "~0.4.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Add the abbility to require coffescript files that contain JSX wrapped in backticks by specifying the `.coffee` extension like so:

``` javascript
require('node-jsx').install({extension: '.coffee'})
```

Then simply require your coffeescript module just like a js one, without specifying its extension.
