### PR TITLE
Support multiple invocations of install.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,20 @@
 var fs = require('fs');
 var React = require('react-tools');
 
-var installed = false;
-
 function install(options) {
-  if (installed) {
-    return;
-  }
-
   options = options || {};
 
   // Import everything in the transformer codepath before we add the import hook
   React.transform('');
 
-  require.extensions[options.extension || '.js'] = function(module, filename) {
+  var extension = options.extension || '.js',
+      transformer = require.extensions[extension]
+
+  if (transformer && transformer._installed) {
+    throw new Error('node-jsx has already been installed for extension ' + extension)
+  }
+
+  transformer = require.extensions[extension] = function(module, filename) {
     var src = fs.readFileSync(filename, {encoding: 'utf8'});
     if (typeof options.additionalTransform == 'function') {
       src = options.additionalTransform(src);
@@ -26,7 +27,9 @@ function install(options) {
     module._compile(src, filename);
   };
 
-  installed = true;
+  transformer._installed = true
+
+  return module.exports
 }
 
 module.exports = {

--- a/node-jsx.spec.js
+++ b/node-jsx.spec.js
@@ -3,4 +3,12 @@ describe('node-jsx', function() {
     require('./index').install();
     expect(require('./test-module')).toBe('jonx');
   });
+  it('should fail with multiple invocations with the same extension', function() {
+    expect(require('./index').install).toThrow();
+  });
+  it('should support multiple invocations with different extensions', function() {
+    require('./index').install({extension: '.jsx'}).install({extension: '.jsy'});
+    expect(require('./test-modulx')).toBe('konx');
+    expect(require('./test-moduly')).toBe('lonx');
+  });
 });

--- a/test-modulx.jsx
+++ b/test-modulx.jsx
@@ -1,0 +1,7 @@
+/** @jsx React.DOM */
+
+function konx() {
+  return 'konx';
+}
+
+module.exports = <konx />;

--- a/test-moduly.jsy
+++ b/test-moduly.jsy
@@ -1,0 +1,7 @@
+/** @jsx React.DOM */
+
+function lonx() {
+  return 'lonx';
+}
+
+module.exports = <lonx />;


### PR DESCRIPTION
This patch allows `install` to be invoked several times for multiple extensions.

Example:

```javascript
var JSX = require('node-jsx')
JSX.install()
JSX.install({extension: '.coffee', additionalTransform: function ... )
```

If the multiple invocation style isn't to your liking I've also made a [multiple-extensions](https://github.com/sbrekken/node-jsx/tree/multiple-extensions) branch that expands options to achieve the same.