### PR TITLE
Added 'addDocblock' option which will add the /** @jsx React.DOM */ comment to the source when it's missing like the 'reactify' module does

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,12 @@
 var fs = require('fs');
 var React = require('react-tools');
+var docblock = require('jstransform/src/docblock');
 
 var installed = false;
+
+function parsePragma(data) {
+  return docblock.parseAsObject(docblock.extract(data)); 
+}
 
 function install(options) {
   if (installed) {
@@ -15,6 +20,11 @@ function install(options) {
 
   require.extensions[options.extension || '.js'] = function(module, filename) {
     var src = fs.readFileSync(filename, {encoding: 'utf8'});
+    if (options.addDocblock) {
+      if (typeof parsePragma(src).jsx === 'undefined') {
+        src = '/** @jsx React.DOM */' + src;
+      }
+    }
     if (typeof options.additionalTransform == 'function') {
       src = options.additionalTransform(src);
     }

--- a/node-jsx.spec.js
+++ b/node-jsx.spec.js
@@ -1,6 +1,6 @@
 describe('node-jsx', function() {
   it('should work', function() {
-    require('./index').install();
+    require('./index').install({ addDocblock: true });
     expect(require('./test-module')).toBe('jonx');
   });
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "transparently require() jsx from node",
   "main": "index.js",
   "dependencies": {
-    "react-tools": "~0.11.0"
+    "react-tools": "~0.11.0",
+    "jstransform": "~6.1.0"
   },
   "devDependencies": {
     "jasmine-node": "1.12.0"

--- a/test-module.js
+++ b/test-module.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 
 function jonx() {
   return 'jonx';


### PR DESCRIPTION
After having used [reactify](https://github.com/andreypopp/reactify) to build my front-end components, I ran into problems with using my components in Node. After investigating the difference in compilation between the  two modules it seemed that the problem is the @jsx instructions missing, which reactify adds automatically when missing.

Instead of updating all my files, I thought this wouldn't be bad optional behaviour for this package either.
