### PR TITLE
Add support for insertPragma, like jsx-loader for webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,12 @@ require('node-jsx').install({
 If you want to use [ES6 transforms](https://github.com/facebook/jstransform/tree/master/visitors) available in the JSX tool
 
 `require('node-jsx').install({harmony: true})`
+
+If you want to automatically add `/** @jsx */` to loaded files do:
+
+`require('node-jsx').install({insertPragma:''});`
+
+Or if you want `/** @jsx React.DOM */`, instead do:
+
+`require('node-jsx').install({insertPragma:'React.DOM'});`
+

--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ function install(options) {
     if (typeof options.additionalTransform == 'function') {
       src = options.additionalTransform(src);
     }
+    if (options.insertPragma) {
+      src = '/** @jsx ' + options.insertPragma + ' */' + src;
+    }
     try {
       src = React.transform(src, options);
     } catch (e) {


### PR DESCRIPTION
This should help with pull request #14 (Added 'addDocblock' option which
will add the /*\* @jsx React.DOM */ comment to the source when it's
missing like the 'reactify' module does) but has the added benefit of
matching webpack's option style, and lets you choose whether or not you
want React.DOM added or not.  Also seems like a simpler pull request
(albeit less correct?)
