### PR TITLE
Increase performance by checking for @jsx comment before compiling.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ function install(options) {
       src = options.additionalTransform(src);
     }
     try {
-      src = React.transform(src, options);
+      if (src.indexOf('/** @jsx React.DOM */') > -1) {
+        src = React.transform(src, options);
+      }
     } catch (e) {
       throw new Error('Error transforming ' + filename + ' to JSX: ' + e.toString());
     }


### PR DESCRIPTION
It saves me some seconds if I only pass files with the @jsx header to React.transform. All other files have no need to be transformed.
