### PR TITLE
Fix dependencies react-tools@0.12.0-rc1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "transparently require() jsx from node",
   "main": "index.js",
   "dependencies": {
-    "react-tools": "~0.12.0"
+    "react-tools": "0.12.0-rc1"
   },
   "devDependencies": {
     "jasmine-node": "1.12.0"


### PR DESCRIPTION
In npm v2.0.0, "~0.12.0" doesn't include 0.12.0-rc1.

http://blog.npmjs.org/post/98131109725/npm-2-0-0
