### PR TITLE
Allow pre- and post- transformation of jsx code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you want to couple with an additional transform (such as CoffeeScript), do:
 var coffee = require('coffee-script');
 require('node-jsx').install({
   extension: '.coffee',
-  preTransform: function(src) {
+  preTransform: function(src, filename) {
     return coffee.compile(src, {
       'bare': true
     });
@@ -34,6 +34,17 @@ var traceur = require('traceur');
 require('node-jsx').install({
   extension: '.jsx',
   postTransform: traceur.compile
+});
+```
+
+Or with babel:
+```javascript
+var babel = require('babel');
+require('node-jsx').install({
+  extension: '.jsx',
+  postTransform: function(src, filename) {
+    return babel.transform(filename).code;
+  }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,19 +10,38 @@ If you want to use a different extension, do:
 
 `require('node-jsx').install({extension: '.jsx'})`
 
+## Additional Transformations
+
+It is possible to combine node-jsx with other source transformations, by either providing a `preTransform` or `postTranform` (or both) function.
+
 If you want to couple with an additional transform (such as CoffeeScript), do:
 
-```
+```javascript
 var coffee = require('coffee-script');
 require('node-jsx').install({
   extension: '.coffee',
-  additionalTransform: function(src) {
+  preTransform: function(src) {
     return coffee.compile(src, {
       'bare': true
     });
   }
 });
 ```
+
+Or to use with traceur:
+```javascript
+var traceur = require('traceur');
+require('node-jsx').install({
+  extension: '.jsx',
+  postTransform: traceur.compile
+});
+```
+
+Traceur compiler does not enjoy JSX syntax, necessitating it being a postTransform.
+
+*Note:* the `preTransform` option was previously called `additionalTransform`, which is soft-deprecated in this release.
+
+## Other options
 
 If you want to use [ES6 transforms](https://github.com/facebook/jstransform/tree/master/visitors) available in the JSX tool
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function install(options) {
       options.preTransform = options.additionalTransform;
     }
     if (typeof options.preTransform == 'function') {
-      src = options.preTransform(src);
+      src = options.preTransform(src, filename);
     }
     try {
       src = React.transform(src, options);
@@ -28,7 +28,7 @@ function install(options) {
       throw new Error('Error transforming ' + filename + ' to JSX: ' + e.toString());
     }
     if (typeof options.postTransform == 'function') {
-      src = options.postTransform(src);
+      src = options.postTransform(src, filename);
     }
     module._compile(src, filename);
   };

--- a/index.js
+++ b/index.js
@@ -16,7 +16,11 @@ function install(options) {
   require.extensions[options.extension || '.js'] = function(module, filename) {
     var src = fs.readFileSync(filename, {encoding: 'utf8'});
     if (typeof options.additionalTransform == 'function') {
-      src = options.additionalTransform(src);
+      console.warn("node-jsx: please change additionalTransform to preTransform");
+      options.preTransform = options.additionalTransform;
+    }
+    if (typeof options.preTransform == 'function') {
+      src = options.preTransform(src);
     }
     try {
       src = React.transform(src, options);

--- a/index.js
+++ b/index.js
@@ -23,6 +23,9 @@ function install(options) {
     } catch (e) {
       throw new Error('Error transforming ' + filename + ' to JSX: ' + e.toString());
     }
+    if (typeof options.postTransform == 'function') {
+      src = options.postTransform(src);
+    }
     module._compile(src, filename);
   };
 


### PR DESCRIPTION
Allow specification of source transformations both before and after jsx. Soft-deprecate `additionalTransform` to make way for new `preTransform` and `postTransform` options. I'd be happy to include some changes that fix the current test, and add tests for the new functionality as well.
