### PR TITLE
performance: add options.checkDocblock to check existance of docblock before transforming

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,10 +18,12 @@ function install(options) {
     if (typeof options.additionalTransform == 'function') {
       src = options.additionalTransform(src);
     }
-    try {
-      src = React.transform(src, options);
-    } catch (e) {
-      throw new Error('Error transforming ' + filename + ' to JSX: ' + e.toString());
+    if (!options.checkDocblock || (src.indexOf('@jsx React.DOM') > -1)) {
+      try {
+        src = React.transform(src, options);
+      } catch (e) {
+        throw new Error('Error transforming ' + filename + ' to JSX: ' + e.toString());
+      }
     }
     module._compile(src, filename);
   };


### PR DESCRIPTION
This change will optionally check the `@jsx React.DOM` docblock prior to transforming. This is disabled by default and enabled via the `checkDocblock` option.

**Motivation:** I have a fairly large app with many dependencies. Without this change, it takes up to 4 seconds to `React.transform` all of the `.js` files. With `checkDocblock` enabled it takes approx. 700ms.

As an alternative, it would have been possible to rename all of the jsx files to use the `.jsx` extension and set the `extension` options; but I prefer not to do that yet and keep the `.js` extension.
