### PR TITLE
Pass filename to transform function

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function install(options) {
 
     var src = fs.readFileSync(filename, {encoding: 'utf8'});
     if (typeof options.additionalTransform == 'function') {
-      src = options.additionalTransform(src);
+      src = options.additionalTransform(src, filename);
     }
     try {
       src = jstransform.transform(src, options).code;


### PR DESCRIPTION
It can be useful to pass the filename to the transform method, to know which file you're transforming (at least in my case it is).  I'm doing a somewhat strange transform, so maybe my use-case is very unique, but it seems like passing the filename to the transform wouldn't hurt anything.
