### PR TITLE
Update license attribute to SPDX value

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
   },
   "repository": "petehunt/node-jsx",
   "author": "Pete Hunt",
-  "license": "Apache 2"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/